### PR TITLE
Prevent blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Community Guidelines"
+    url: "https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md"
+    about: "Please make sure to follow the PSF Code of Conduct when participating in this repository."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: "Community Guidelines"
-    url: "https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md"
-    about: "Please make sure to follow the PSF Code of Conduct when participating in this repository."
+  - name: Community Guidelines
+    url: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+    about: Please make sure to follow the PSF Code of Conduct when participating in this repository.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,8 @@ contact_links:
   - name: Community Guidelines
     url: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
     about: Please make sure to follow the PSF Code of Conduct when participating in this repository.
+  - name: Python Packaging User Guide
+    url: https://packaging.python.org/en/latest/
+    about: |
+      Collection of tutorials and references to help you distribute and install Python packages.
+      For contributions and suggestions please check https://packaging.python.org/en/latest/contribute/.


### PR DESCRIPTION
I noticed that we received some spam in this repository, I wonder if disallowing blank issues can help a little bit.

Since the repository already has a form for [general issue](https://github.com/pypa/packaging-problems/blob/master/.github/ISSUE_TEMPLATE/general_issue.yml), we possibly can simply disable the blank ones.

(I created a PR with similar purpose in https://github.com/pypa/packaging.python.org/pull/1653)